### PR TITLE
Fix typo in Portuguese locale

### DIFF
--- a/strftime.js
+++ b/strftime.js
@@ -176,7 +176,7 @@
           pm: 'pm',
           formats: {
                 c: '%a %d %b %Y %X %Z',
-                D: '%d-$m-%Y',
+                D: '%d-%m-%Y',
                 F: '%Y-%m-%d',
                 R: '%H:%M',
                 r: '%I:%M:%S %p',


### PR DESCRIPTION
This was causing dates in Portuguese to be shown like '28-$m-2016' since the '$m' was taken literally.
